### PR TITLE
When n_outputs is set, save only that many outputs from the simulation function

### DIFF
--- a/@xgrid/simulate_core.m
+++ b/@xgrid/simulate_core.m
@@ -1,12 +1,12 @@
-%                          _                                       
-%                         | |                                      
-%     _ __  ___ _   _  ___| |__   ___  _ __   ___  _ __ ___  _ __  
-%    | '_ \/ __| | | |/ __| '_ \ / _ \| '_ \ / _ \| '_ ` _ \| '_ \ 
+%                          _
+%                         | |
+%     _ __  ___ _   _  ___| |__   ___  _ __   ___  _ __ ___  _ __
+%    | '_ \/ __| | | |/ __| '_ \ / _ \| '_ \ / _ \| '_ ` _ \| '_ \
 %    | |_) \__ \ |_| | (__| | | | (_) | |_) | (_) | | | | | | |_) |
-%    | .__/|___/\__, |\___|_| |_|\___/| .__/ \___/|_| |_| |_| .__/ 
-%    | |         __/ |                | |                   | |    
+%    | .__/|___/\__, |\___|_| |_|\___/| .__/ \___/|_| |_| |_| .__/
+%    | |         __/ |                | |                   | |
 %    |_|        |___/                 |_|                   |_|
-%  
+%
 
 
 function simulate_core(self,idx,n_runs)
@@ -17,7 +17,7 @@ function simulate_core(self,idx,n_runs)
 
 	while n_runs > 0
 
-		% grab a job file and move it to doing 
+		% grab a job file and move it to doing
 		do_folder = [self.xgrid_folder filesep 'do' filesep ];
 		doing_folder = [self.xgrid_folder filesep 'doing' filesep ];
 		done_folder = [self.xgrid_folder filesep 'done' filesep ];
@@ -40,14 +40,14 @@ function simulate_core(self,idx,n_runs)
 			continue
 		end
 
-		% load the file 
+		% load the file
 		load([doing_folder this_job],'-mat')
 
 
 		% check that the hash matches
 		assert(strcmp(xhash,self.xolotl_hash),'Hashes dont match')
 
-		
+
 		for i = 1:size(this_params,2)
 			% update params
 
@@ -58,7 +58,12 @@ function simulate_core(self,idx,n_runs)
 
 
 			try
-				[outputs{1:length(corelib.argOutNames(self.sim_func))}] = self.sim_func(self.x);
+				if isempty(self.n_outputs) | isnan(self.n_outputs)
+					n_outputs = length(corelib.argOutNames(self.sim_func));
+				else
+					n_outputs = self.n_outputs;
+				end
+				[outputs{1:n_outputs}] = self.sim_func(self.x);
 				sim_ok = true;
 			catch err
 				disp(err)
@@ -101,7 +106,7 @@ function simulate_core(self,idx,n_runs)
 		end
 
 		% some defensive measures to make sure that data
-		% and params are aligned 
+		% and params are aligned
 		ok = true;
 		for j = 1:length(data)
 			if size(data{j},2) ~= size(this_params,2)
@@ -117,7 +122,7 @@ function simulate_core(self,idx,n_runs)
 			movefile([doing_folder this_job],[done_folder this_job])
 
 		else
-			% not OK. give up. 
+			% not OK. give up.
 			disp('Something went wrong with this job:')
 			disp(this_job)
 			disp('This job will remain stuck in the doing queue')
@@ -128,5 +133,5 @@ function simulate_core(self,idx,n_runs)
 		clear data this_params param_idx param_names xhash
 		n_runs = n_runs - 1;
 	end
-	
+
 end

--- a/@xgrid/simulate_core.m
+++ b/@xgrid/simulate_core.m
@@ -58,7 +58,7 @@ function simulate_core(self,idx,n_runs)
 
 
 			try
-				if isempty(self.n_outputs) | isnan(self.n_outputs)
+				if isempty(self.n_outputs) || isnan(self.n_outputs)
 					n_outputs = length(corelib.argOutNames(self.sim_func));
 				else
 					n_outputs = self.n_outputs;

--- a/@xgrid/xgrid.m
+++ b/@xgrid/xgrid.m
@@ -26,8 +26,7 @@ classdef xgrid < handle & matlab.mixin.CustomDisplay
 
 		num_workers
 
-
-
+		n_outputs
 
 	end % end props
 
@@ -44,7 +43,6 @@ classdef xgrid < handle & matlab.mixin.CustomDisplay
 		is_master = false;
 		speed
 
-		n_outputs
 
 
 	end

--- a/@xgrid/xgrid.m
+++ b/@xgrid/xgrid.m
@@ -28,12 +28,12 @@ classdef xgrid < handle & matlab.mixin.CustomDisplay
 
 
 
-		
+
 	end % end props
 
 	properties (SetAccess = protected)
 		allowed_param_names
-		
+
 		workers
 		n_sims
 		xolotl_hash
@@ -42,11 +42,11 @@ classdef xgrid < handle & matlab.mixin.CustomDisplay
 		controller_handle
 
 		is_master = false;
-		speed 
+		speed
 
 		n_outputs
 
-		
+
 	end
 
 	properties (Access = protected)
@@ -61,7 +61,7 @@ classdef xgrid < handle & matlab.mixin.CustomDisplay
         function displayScalarObject(self)
             url = 'https://github.com/sg-s/xgrid/';
             fprintf(['\b\b\b\b\b\b<a href="' url '">xgrid</a> '])
-            if isempty(self.clusters) 
+            if isempty(self.clusters)
             	 fprintf('is not connected to any cluster!')
             else
             	for i = 1:length(self.clusters)
@@ -78,7 +78,7 @@ classdef xgrid < handle & matlab.mixin.CustomDisplay
 					xhash = self.xolotl_hash;
 					status = '';
 				else
-					
+
 
 					if ~isfield(self.clusters(i),'plog')
 						return
@@ -104,7 +104,7 @@ classdef xgrid < handle & matlab.mixin.CustomDisplay
 						end
 					end
 				end
-				if isempty(xhash) 
+				if isempty(xhash)
 					xhash = 'n/a         ';
 				end
 				fprintf([cluster_name_disp  ' ' strlib.fix(status,7) ' ' strlib.fix(strlib.oval(n_do),7) ' ' strlib.fix(strlib.oval(n_doing),8) ' ' strlib.fix(strlib.oval(n_done),5) ' ' xhash(1:7) '\n'])
@@ -115,7 +115,7 @@ classdef xgrid < handle & matlab.mixin.CustomDisplay
             url = ['matlab:' inputname(1) '.showWorkerStates'];
             fprintf(['\n<a href="' url '">show worker states</a> \n'])
 
-     
+
 
         end % end displayScalarObject
    end % end protected methods
@@ -128,7 +128,7 @@ classdef xgrid < handle & matlab.mixin.CustomDisplay
 		% when run with no input arguments, will run as slave
 		% when called with any argument, will run as master
 		function self = xgrid(varargin)
-			
+
 
 			if ispc
 				error('xgrid cannot run on a Windows computer')
@@ -180,7 +180,7 @@ classdef xgrid < handle & matlab.mixin.CustomDisplay
 			fs = func2str(value);
 			loc = which(fs);
 			assert(~isempty(loc),'Sim func could not be located')
-		
+
 
 			self.sim_func = value;
 
@@ -193,7 +193,7 @@ classdef xgrid < handle & matlab.mixin.CustomDisplay
 				% copy the sim function onto the remote
 				netlib.copyFun(value,[self.clusters(i).Name ':~/.psych/']);
 
-	
+
 				% tell the remote to use this
 				command = ['sim_func = @' func2str(value) ';'];
 				self.tellRemote(self.clusters(i).Name,command);
@@ -214,7 +214,7 @@ classdef xgrid < handle & matlab.mixin.CustomDisplay
 				% in ~/.psych/, and force cpplab to
 				% only use those files
 				cpplab.rebuildCache({'~/.psych/'})
-				self.x.rebase;			
+				self.x.rebase;
 			end
 
 


### PR DESCRIPTION
* Made the `n_outputs` property writeable
* `simulate_core` only saves the first `n_outputs` outputs of the simulation function when `n_outputs` is non-NaN and non-empty.